### PR TITLE
Added a script for querying neo4j

### DIFF
--- a/neo
+++ b/neo
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+from py2neo import Graph
+from sys import argv
+from os import environ
+
+auth = environ["NEO4J_USERNAME"] + ":" + environ["NEO4J_PASSWORD"]
+uri = "http://" + auth + "@localhost:7474/db/data"
+graph = Graph(uri)
+
+if len(argv) > 1 and argv[1] != 'show':
+    command = 'MATCH (n) DELETE n' if argv[1] == 'drop' else argv[1]
+    graph.cypher.execute(command)
+
+print graph.cypher.execute('MATCH (n) RETURN n')


### PR DESCRIPTION
# ./neo

Who needs pretty in-browser interfaces, anyway? With the help of this little script, you'll no longer have to switch to your browser to interact with your database :clap: 

``` bash
usage: ./neo [show|drop|cypher_statement] 
```

**show:** prints data currently in the database (implied)
**drop:** deletes everything in the database
**_cypher_statement_:** any valid cypher statement string

---

PS: "show" is just there for kicks, all data in the neo4j database is printed after the script does it's thing.

PPS: This is just to help speed up the development process and isn't meant to be used when handling data that you intend to keep.
